### PR TITLE
🔧 Fix DB error and add configuration of API_HOST

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 API_KEY=<APIKEY HERE>
+API_HOST=https://api.us-east-1.mbedcloud.com
 APP_HOST=https://<HOSTNAME>/
 DEVICE_ID=*
 RESOURCE=*

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,3 +18,4 @@ services:
     image: postgres:alpine
     environment:
       POSTGRES_USER: postgres
+      POSTGRES_HOST_AUTH_METHOD: trust

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,7 @@ services:
     environment:
       DATABASE_URL: postgres://postgres:example@db:5432/postgres
       API_KEY: ${API_KEY}
+      API_HOST: ${API_HOST}
       DEVICE_ID: ${DEVICE_ID}
       RESOURCE: ${RESOURCE}
       LONG_POLLING_ENABLED: ${LONG_POLLING_ENABLED}


### PR DESCRIPTION
1.  Fix Error: getaddrinfo ENOTFOUND db
2.  Add configuration of API_HOST